### PR TITLE
Update BLE find robot by name to fix macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.9"
 pyserial = "^3.4"
-bleak = "^0.19.0"
+bleak = "^0.20.0"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Update Bleak to 0.20.0 in order to use BleakScanner.find_device_by_name() and update usage of .discover() to avoid deprecated class members.